### PR TITLE
concurrency.jar added to LTL fileset build (fixes #5)

### DIFF
--- a/Ltl/build.xml
+++ b/Ltl/build.xml
@@ -165,6 +165,9 @@
         <fileset dir="../">
           <include name="beepbeep-3.jar"/>
         </fileset>
+		<fileset dir="../">
+          <include name="concurrency.jar"/>
+        </fileset>
         <pathelement location="${build.libdir}/${junit.jarname}"/>
         <pathelement location="${build.libdir}/${junit.hamcrest}"/>
       </classpath>
@@ -226,6 +229,9 @@
           <include name="*.jar"/>
         </fileset>
         <pathelement path="${java.class.path}"/>
+		<fileset dir="../">
+          <include name="concurrency.jar"/>
+        </fileset>
         <pathelement location="${build.libdir}/${junit.jarname}"/>
         <pathelement location="${build.libdir}/${junit.hamcrest}"/>
         <fileset dir="../">


### PR DESCRIPTION
Added `concurrency.jar` to file set in the `LTL/build.xml` in order to resolve #5.
Works great, however please note that:
* In case of building only the LTL palette, you must compile `concurrency.jar` beforehand, and it must be present in the root directory of all the palettes!
* In case of building all the palettes using `build-all.sh`, **this works only because `concurrency` comes first in alphabetical order**. Thus, if it were positionned after the LTL directory, it would not work (could be problematic with a potential big refactoring/renaming). Maybe @sylvainhalle would have a cleaner solution?
